### PR TITLE
Updated to the non-deprecated install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ development and hacking.
 ## Usage
 ### Installation
 ```sh
-go get -u github.com/polyfloyd/shady/cmd/shady
+go install github.com/polyfloyd/shady/cmd/shady@latest
 ```
 
 ### Shadertoy


### PR DESCRIPTION
`get -u` is deprecated and the the preferred install method is to use `install` instead.

See: https://medium.com/@sherlock297/go-get-installing-executables-with-go-get-in-module-mode-is-deprecated-de3a30439596